### PR TITLE
Fix destructive innerText replacements in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "rm -rf dist-test && tsc -p tsconfig.test.json && node --experimental-specifier-resolution=node --test dist-test/tests/replace-helper.test.js"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",

--- a/src/components/editor/textReplacement.ts
+++ b/src/components/editor/textReplacement.ts
@@ -1,0 +1,80 @@
+/**
+ * Applies regex-based replacements across all text nodes within the provided root element.
+ *
+ * This utility preserves the existing DOM structure by restricting replacements to text nodes,
+ * preventing the destructive flattening that occurs when rewriting `innerText` for complex
+ * screenplay documents that rely on semantic block wrappers.
+ *
+ * @param {HTMLElement} root - The root element containing screenplay markup.
+ * @param {string} patternSource - The regex source string to apply.
+ * @param {string} patternFlags - The regex flags to honour when building matchers.
+ * @param {string} replacement - The replacement string to inject for each match.
+ * @param {boolean} replaceAll - Whether replacements should continue after the first match.
+ * @returns {number} The total number of replacements applied across all text nodes.
+ */
+export function applyRegexReplacementToTextNodes(
+  root: HTMLElement,
+  patternSource: string,
+  patternFlags: string,
+  replacement: string,
+  replaceAll: boolean
+): number {
+  const combinedFlags = Array.from(new Set((patternFlags + 'g').split(''))).join('');
+  const maxReplacements = replaceAll ? Number.POSITIVE_INFINITY : 1;
+  const TEXT_NODE = 3;
+
+  let remaining = maxReplacements;
+  let replacementsApplied = 0;
+
+  const traverse = (node: any) => {
+    if (!node || remaining === 0) return;
+
+    if (typeof node.nodeType === 'number' && node.nodeType === TEXT_NODE) {
+      const originalText = node.nodeValue ?? node.textContent ?? '';
+      if (!originalText) {
+        return;
+      }
+
+      const regex = new RegExp(patternSource, combinedFlags);
+      let nodeChanged = false;
+
+      const updatedText = originalText.replace(regex, (match: string) => {
+        if (remaining === 0) {
+          return match;
+        }
+
+        nodeChanged = true;
+        replacementsApplied += 1;
+
+        if (remaining !== Number.POSITIVE_INFINITY) {
+          remaining -= 1;
+        }
+
+        return replacement;
+      });
+
+      if (nodeChanged) {
+        if ('nodeValue' in node) {
+          node.nodeValue = updatedText;
+        } else if ('textContent' in node) {
+          node.textContent = updatedText;
+        }
+      }
+
+      return;
+    }
+
+    const children: any[] = Array.isArray(node?.childNodes)
+      ? node.childNodes
+      : Array.from(node?.childNodes ?? []);
+
+    for (const child of children) {
+      if (remaining === 0) break;
+      traverse(child);
+    }
+  };
+
+  traverse(root);
+
+  return replacementsApplied;
+}

--- a/tests/replace-helper.test.ts
+++ b/tests/replace-helper.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyRegexReplacementToTextNodes } from '../src/components/editor/textReplacement.js';
+
+type StubNode = {
+  nodeType: number;
+  nodeValue?: string;
+  textContent?: string;
+  childNodes?: StubNode[];
+};
+
+const TEXT_NODE = 3;
+const ELEMENT_NODE = 1;
+
+const createTextNode = (text: string): StubNode => ({
+  nodeType: TEXT_NODE,
+  nodeValue: text,
+});
+
+const createElementNode = (children: StubNode[] = []): StubNode => ({
+  nodeType: ELEMENT_NODE,
+  childNodes: children,
+});
+
+const collectTextNodes = (node: StubNode): string[] => {
+  if (node.nodeType === TEXT_NODE) {
+    return [node.nodeValue ?? node.textContent ?? ''];
+  }
+
+  return (node.childNodes ?? []).flatMap(collectTextNodes);
+};
+
+describe('applyRegexReplacementToTextNodes', () => {
+  it('preserves screenplay block structure while replacing text occurrences', () => {
+    const root = createElementNode([
+      createElementNode([createTextNode('بسم الله الرحمن الرحيم')]),
+      createElementNode([createTextNode('مشهد 1')]),
+      createElementNode([createTextNode('مرحبا بك في المشهد'), createTextNode('مرحبا مجدداً')]),
+    ]);
+
+    const originalChildCount = root.childNodes?.length ?? 0;
+
+    const replacements = applyRegexReplacementToTextNodes(
+      root as unknown as HTMLElement,
+      'مرحبا',
+      'gi',
+      'أهلاً',
+      true
+    );
+
+    assert.equal(replacements, 2, 'should report both replacements');
+    assert.equal(root.childNodes?.length ?? 0, originalChildCount, 'should retain block elements');
+
+    const textContents = collectTextNodes(root);
+    assert.deepEqual(textContents, [
+      'بسم الله الرحمن الرحيم',
+      'مشهد 1',
+      'أهلاً بك في المشهد',
+      'أهلاً مجدداً',
+    ]);
+  });
+
+  it('honours replaceAll=false by updating only the first occurrence', () => {
+    const root = createElementNode([
+      createElementNode([createTextNode('الاسم'), createTextNode('OLD NAME')]),
+      createElementNode([createTextNode('OLD NAME')]),
+    ]);
+
+    const replacements = applyRegexReplacementToTextNodes(
+      root as unknown as HTMLElement,
+      'OLD NAME',
+      'g',
+      'NEW NAME',
+      false
+    );
+
+    assert.equal(replacements, 1, 'should stop after first replacement');
+
+    const textContents = collectTextNodes(root);
+    assert.deepEqual(textContents, ['الاسم', 'NEW NAME', 'OLD NAME']);
+  });
+
+  it('supports anchored rename patterns used for character headings', () => {
+    const root = createElementNode([
+      createElementNode([createTextNode('  سارة  ')]),
+      createElementNode([createTextNode('سارة: تقول شيئاً')]),
+    ]);
+
+    const replacements = applyRegexReplacementToTextNodes(
+      root as unknown as HTMLElement,
+      '^\\s*سارة\\s*$',
+      'gmi',
+      'لينا',
+      true
+    );
+
+    assert.equal(replacements, 1, 'should only rename standalone headings');
+
+    const textContents = collectTextNodes(root);
+    assert.deepEqual(textContents, ['لينا', 'سارة: تقول شيئاً']);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-test",
+    "emitDeclarationOnly": false,
+    "module": "ESNext",
+    "target": "ES2020",
+    "jsx": "react-jsx",
+    "allowImportingTsExtensions": false,
+    "moduleResolution": "node"
+  },
+  "include": [
+    "tests/**/*.ts",
+    "src/components/editor/textReplacement.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- ensure replace operations gather regex metadata for safe DOM updates
- add reusable DOM text replacement helper and node-based tests to prevent markup loss
- update find/replace and character rename flows to preserve screenplay formatting and handle missing matches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d87d3df1b8832891be2f2203adabfc